### PR TITLE
Trivial "timeline" renderer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,10 @@ name = "toot"
 version = "0.1.0"
 dependencies = [
  "iron 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logger 0.0.3 (git+https://github.com/iron/logger.git)",
+ "mustache 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -149,6 +152,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "logger"
+version = "0.0.3"
+source = "git+https://github.com/iron/logger.git#e3cf7420b4f24dc234c80a58399aefb3c769a0aa"
+dependencies = [
+ "iron 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +178,15 @@ dependencies = [
 name = "modifier"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mustache"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num_cpus"
@@ -261,6 +283,15 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,14 @@ authors = ["Owen Jacobson <owen.jacobson@grimoire.ca>"]
 [dependencies.iron]
 version = "*"
 
+[dependencies.logger]
+git = "https://github.com/iron/logger.git"
+
+[dependencies.mustache]
+version = "*"
+
 [dependencies.router]
+version = "*"
+
+[dependencies.rustc-serialize]
 version = "*"

--- a/templates/timeline.html
+++ b/templates/timeline.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <h1>
+            Hello {{ user }}! 😡
+        </h1>
+    </body>
+</html>


### PR DESCRIPTION
Supports (requires) usernames. Abuses `.unwrap()` mercilessly. Uses Mustache,
because that's the only template language widely supported in Rust.